### PR TITLE
Fix symbol naming error in example.rs

### DIFF
--- a/src/example.rs
+++ b/src/example.rs
@@ -83,9 +83,9 @@ fn conv(input: *const c_char) -> String {
 }
 
 #[no_mangle]
-pub extern fn init_function(_	: *const VrtCtx,
-			    prv	: &mut vmod_priv,
-			    ev	: VclEvent ) -> c_int{
+pub extern fn vmod_init_function(_	: *const VrtCtx,
+			    	prv	: &mut vmod_priv,
+			    	ev	: VclEvent ) -> c_int{
 	match ev {
 		VclEvent::Warm => {
 			let hash = Mutex::new(HashMap::new());


### PR DESCRIPTION
This fixes the following bug (observed with Rust `1.54.0` and varnishd `6.6`, but I don't think that is relevant)

```
***  v1    debug|Could not delete 'vcl_vcl1.1639575533.677239/vgc.sym': No such file or directory
***  v1    CLI RX  106
**** v1    CLI RX|Message from VCC-compiler:
**** v1    CLI RX|Could not open VMOD example
**** v1    CLI RX|\tFile name: /home/vagrant/example/src/.libs/libvmod_example.so
**** v1    CLI RX|\tdlerror: /home/vagrant/example/src/.libs/libvmod_example.so: undefined symbol: vmod_init_function
**** v1    CLI RX|('<vcl.inline>' Line 5 Pos 16)
**** v1    CLI RX|        import example from "/home/vagrant/example/src/.libs/libvmod_example.so";
**** v1    CLI RX|---------------####------------------------------------------------------------
**** v1    CLI RX|
**** v1    CLI RX|Running VCC-compiler failed, exited with 2
```